### PR TITLE
feat: add 14 day delay to renovate package upgrade PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchDepTypes": ["dependencies", "devDependencies"],
+      "minimumReleaseAge": "14 days",
+      "internalChecksFilter": "strict"
+    }
   ]
 }


### PR DESCRIPTION
https://app.shortcut.com/narrativeio/story/50523/renovate-and-dependabot-should-delay-the-adoption-of-new-package-versions