### PR TITLE
chore: make renovate the sole actions bot with a universal 14-day cooldown (sc-63552)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-# Keeps the SHA-pinned actions in .github/workflows fresh.
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 14

--- a/renovate.json
+++ b/renovate.json
@@ -3,11 +3,6 @@
   "extends": [
     "config:recommended"
   ],
-  "packageRules": [
-    {
-      "matchDepTypes": ["dependencies", "devDependencies"],
-      "minimumReleaseAge": "14 days",
-      "internalChecksFilter": "strict"
-    }
-  ]
+  "minimumReleaseAge": "14 days",
+  "internalChecksFilter": "strict"
 }


### PR DESCRIPTION
Removes the redundant Dependabot config and applies a top-level 14-day cooldown to all Renovate-managed dependencies. [sc-63552](https://app.shortcut.com/narrativeio/story/63552)